### PR TITLE
fix: Increase MMLU test questions to 20 for proper completion

### DIFF
--- a/src/components/pages/TestPage.tsx
+++ b/src/components/pages/TestPage.tsx
@@ -94,7 +94,7 @@ const MMLUTestPage: React.FC = () => {
         return;
       }
 
-      const questionsToUse = Math.min(8, availableQuestions); // Use up to 8 questions, but no more than available
+      const questionsToUse = Math.min(20, availableQuestions); // Use up to 20 questions, but no more than available
 
       const session = getRandomQuestionsForSession(selectedCategoryId, questionsToUse);
       setCurrentSession(session);

--- a/src/utils/questionDataManager.ts
+++ b/src/utils/questionDataManager.ts
@@ -62,12 +62,12 @@ let availableCategories: string[] = [];
 const MMLU_CATEGORIES = [
   'college_mathematics',
   'world_history',
-  'college_physics', 
+  'college_physics',
   'computer_science',
   'philosophy',
   'college_medicine',
   'econometrics',
-  'world_religions'
+  'world_religions',
 ] as const;
 
 // =============================================================================
@@ -84,12 +84,12 @@ export async function loadQuestionData(): Promise<QuestionPool> {
 
   try {
     const pool: QuestionPool = {};
-    
+
     for (const categoryId of MMLU_CATEGORIES) {
       try {
         // 動的インポートでJSONデータを読み込み
         const categoryData = await import(`../data/questions/mmlu/${categoryId}.json`);
-        
+
         // データ検証
         if (!validateCategoryData(categoryData.default)) {
           throw new QuestionDataErrorImpl(
@@ -98,29 +98,24 @@ export async function loadQuestionData(): Promise<QuestionPool> {
             categoryId
           );
         }
-        
+
         pool[categoryId] = categoryData.default;
         console.log(`Loaded ${categoryData.default.questions.length} questions for ${categoryId}`);
-        
       } catch (error) {
         console.warn(`Failed to load category ${categoryId}:`, error);
         // 個別カテゴリの読み込み失敗は続行
       }
     }
-    
+
     if (Object.keys(pool).length === 0) {
-      throw new QuestionDataErrorImpl(
-        'No question categories could be loaded',
-        'LOAD_ERROR'
-      );
+      throw new QuestionDataErrorImpl('No question categories could be loaded', 'LOAD_ERROR');
     }
-    
+
     questionPool = pool;
     availableCategories = Object.keys(pool);
-    
+
     console.log(`Question pool loaded with ${availableCategories.length} categories`);
     return pool;
-    
   } catch (error) {
     throw new QuestionDataErrorImpl(
       `Failed to load question data: ${error}`,
@@ -156,35 +151,43 @@ function validateCategoryData(data: unknown): data is QuestionCategory {
   if (!data || typeof data !== 'object') {
     return false;
   }
-  
+
   const category = data as Record<string, unknown>;
-  
+
   // メタデータの検証
   if (!category.metadata || typeof category.metadata !== 'object') {
     return false;
   }
-  
+
   const metadata = category.metadata as Record<string, unknown>;
-  const requiredMetadataFields = ['category', 'name', 'description', 'domain', 'difficulty', 'source', 'pool_size'];
-  
+  const requiredMetadataFields = [
+    'category',
+    'name',
+    'description',
+    'domain',
+    'difficulty',
+    'source',
+    'pool_size',
+  ];
+
   for (const field of requiredMetadataFields) {
     if (!(field in metadata)) {
       return false;
     }
   }
-  
+
   // 問題データの検証
   if (!Array.isArray(category.questions)) {
     return false;
   }
-  
+
   // 各問題の基本的な検証
   for (const question of category.questions) {
     if (!validateQuestionFormat(question)) {
       return false;
     }
   }
-  
+
   return true;
 }
 
@@ -195,30 +198,30 @@ function validateQuestionFormat(question: unknown): question is MMLUQuestion {
   if (!question || typeof question !== 'object') {
     return false;
   }
-  
+
   const q = question as Record<string, unknown>;
-  
+
   const requiredFields = ['id', 'type', 'question', 'choices', 'correctAnswer', 'category'];
-  
+
   for (const field of requiredFields) {
     if (!(field in q)) {
       return false;
     }
   }
-  
+
   // 型チェック
   if (q.type !== 'multiple-choice') {
     return false;
   }
-  
+
   if (!Array.isArray(q.choices) || q.choices.length !== 4) {
     return false;
   }
-  
+
   if (typeof q.correctAnswer !== 'number' || q.correctAnswer < 0 || q.correctAnswer > 3) {
     return false;
   }
-  
+
   return true;
 }
 
@@ -228,27 +231,27 @@ function validateQuestionFormat(question: unknown): question is MMLUQuestion {
 export function validateQuestionData(): { valid: boolean; errors: string[]; warnings: string[] } {
   const errors: string[] = [];
   const warnings: string[] = [];
-  
+
   if (!questionPool) {
     errors.push('Question pool not loaded');
     return { valid: false, errors, warnings };
   }
-  
+
   for (const [categoryId, categoryData] of Object.entries(questionPool)) {
     const questions = categoryData.questions;
-    
+
     // 重複ID検証
-    const questionIds = questions.map(q => q.id);
+    const questionIds = questions.map((q) => q.id);
     const uniqueIds = new Set(questionIds);
     if (questionIds.length !== uniqueIds.size) {
       errors.push(`Duplicate question IDs found in category: ${categoryId}`);
     }
-    
+
     // 問題数検証
     if (questions.length < 10) {
       warnings.push(`Category ${categoryId} has only ${questions.length} questions`);
     }
-    
+
     // correctAnswerの検証
     for (const question of questions) {
       if (question.correctAnswer >= question.choices.length) {
@@ -256,11 +259,11 @@ export function validateQuestionData(): { valid: boolean; errors: string[]; warn
       }
     }
   }
-  
+
   return {
     valid: errors.length === 0,
     errors,
-    warnings
+    warnings,
   };
 }
 
@@ -275,14 +278,14 @@ export function getQuestionById(questionId: string): MMLUQuestion | null {
   if (!questionPool) {
     return null;
   }
-  
+
   for (const categoryData of Object.values(questionPool)) {
-    const question = categoryData.questions.find(q => q.id === questionId);
+    const question = categoryData.questions.find((q) => q.id === questionId);
     if (question) {
       return question;
     }
   }
-  
+
   return null;
 }
 
@@ -293,7 +296,7 @@ export function getQuestionsByCategory(categoryId: string): MMLUQuestion[] {
   if (!questionPool || !questionPool[categoryId]) {
     return [];
   }
-  
+
   return [...questionPool[categoryId].questions];
 }
 
@@ -302,7 +305,7 @@ export function getQuestionsByCategory(categoryId: string): MMLUQuestion[] {
  */
 export function getRandomQuestionsForSession(
   categoryId: string,
-  count: number = 12
+  count: number = 20 // 12から20に変更
 ): SessionQuestions {
   if (!questionPool || !questionPool[categoryId]) {
     throw new QuestionDataErrorImpl(
@@ -311,10 +314,10 @@ export function getRandomQuestionsForSession(
       categoryId
     );
   }
-  
+
   const categoryData = questionPool[categoryId];
   const allQuestions = [...categoryData.questions];
-  
+
   if (allQuestions.length < count) {
     throw new QuestionDataErrorImpl(
       `Insufficient questions in category ${categoryId}: requested ${count}, available ${allQuestions.length}`,
@@ -322,16 +325,16 @@ export function getRandomQuestionsForSession(
       categoryId
     );
   }
-  
+
   // Fisher-Yates シャッフルアルゴリズム
   const shuffled = shuffleQuestions(allQuestions);
   const selectedQuestions = shuffled.slice(0, count);
-  
+
   return {
     categoryId,
     categoryName: categoryData.metadata.name,
     questions: selectedQuestions,
-    totalInPool: allQuestions.length
+    totalInPool: allQuestions.length,
   };
 }
 
@@ -340,9 +343,9 @@ export function getRandomQuestionsForSession(
  */
 export function getRandomQuestionsForMultiCategorySession(
   categoryIds: string[],
-  questionsPerCategory: number = 12
+  questionsPerCategory: number = 20 // 12から20に変更
 ): SessionQuestions[] {
-  return categoryIds.map(categoryId => 
+  return categoryIds.map((categoryId) =>
     getRandomQuestionsForSession(categoryId, questionsPerCategory)
   );
 }
@@ -356,12 +359,12 @@ export function getRandomQuestionsForMultiCategorySession(
  */
 export function shuffleQuestions<T>(array: T[]): T[] {
   const shuffled = [...array];
-  
+
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
-  
+
   return shuffled;
 }
 
@@ -387,12 +390,12 @@ export function getCategorySummary(): Array<{
   if (!questionPool) {
     return [];
   }
-  
+
   return Object.entries(questionPool).map(([id, data]) => ({
     id,
     name: data.metadata.name,
     domain: data.metadata.domain,
     difficulty: data.metadata.difficulty,
-    questionCount: data.questions.length
+    questionCount: data.questions.length,
   }));
 }


### PR DESCRIPTION
## Summary
Fix the MMLU test completion issue where tests with 8/8 questions answered would not complete due to hardcoded 20-question completion threshold.

## Problem
- Users could answer all 8 questions but test wouldn't complete
- `checkTestCompletion` function required 20 answered questions
- Test interface was limiting to only 8 questions per session

## Solution
- Increase question count from 8 to 20 in `TestPage.tsx`
- Update default question count from 12 to 20 in `questionDataManager.ts`
- Maintain existing 20-question completion threshold logic
- Use available 20 questions per category from existing data

## Changes
- **TestPage.tsx**: Changed `Math.min(8, availableQuestions)` → `Math.min(20, availableQuestions)`
- **questionDataManager.ts**: Updated default counts from 12 → 20 in:
  - `getRandomQuestionsForSession`
  - `getRandomQuestionsForMultiCategorySession`

## Test Plan
- [x] Tests now display 20 questions instead of 8
- [x] Test completion triggers properly at 20/20 questions
- [x] Existing question data supports 20 questions per category
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>